### PR TITLE
Make RM/MITC element kernels allocation-free

### DIFF
--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -362,8 +362,7 @@ function membrane_tangent_RM!(ke, scv::ShellCellValues, u_e::AbstractVector{T}, 
     for qp in 1:getnquadpoints(scv)
         a₁, a₂ = covariant_basis(scv, qp, u_e, n_nodes)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
-        N, C = membrane_stress_and_tangent(mat, c_ms, scv.A_metric[qp],
-                   scv.A₁[qp], scv.A₂[qp], G₃)
+        N, C = membrane_stress_and_tangent(mat, c_ms, scv.A_metric[qp], scv.A₁[qp], scv.A₂[qp], G₃)
         M₁₁, M₁₂, M₂₂ = frame_stiffness(C, a₁, a₂)
         dΩ = scv.detJdV[qp]
         for I in 1:n_nodes
@@ -409,8 +408,7 @@ function bending_residuals_RM!(re, scv::ShellCellValues, u_e::AbstractVector{T},
         d₀  = reference_director(scv, qp, n_nodes)
         γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
-        D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp],
-                   scv.A₁[qp], scv.A₂[qp], d₀)
+        D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp], scv.A₁[qp], scv.A₂[qp], d₀)
         M   = D ⊡ κ
         Q₁  = Cs[1,1]*γ₁ + Cs[1,2]*γ₂
         Q₂  = Cs[2,1]*γ₁ + Cs[2,2]*γ₂
@@ -514,8 +512,7 @@ function bending_tangent_RM!(ke, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::Abs
         d₀  = reference_director(scv, qp, n_nodes)
         γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
-        D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp],
-                   scv.A₁[qp], scv.A₂[qp], d₀)
+        D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp], scv.A₁[qp], scv.A₂[qp], d₀)
         Mb  = D ⊡ κ
         Q₁  = Cs[1,1]*γ₁ + Cs[1,2]*γ₂
         Q₂  = Cs[2,1]*γ₁ + Cs[2,2]*γ₂
@@ -614,8 +611,7 @@ function bending_tangent_RM!(ke, scv::ShellCellValues, u_e::AbstractVector{T}, m
         d₀  = reference_director(scv, qp, n_nodes)
         γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
-        D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp],
-                   scv.A₁[qp], scv.A₂[qp], d₀)
+        D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp], scv.A₁[qp], scv.A₂[qp], d₀)
         M   = D ⊡ κ
         Q₁  = Cs[1,1]*γ₁ + Cs[1,2]*γ₂
         Q₂  = Cs[2,1]*γ₁ + Cs[2,2]*γ₂

--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -49,14 +49,14 @@ end
 @inline function director_field(scv, qp, u_e::AbstractVector{T}, n_nodes) where T
     d = zero(Vec{3,T}); d₁ = zero(Vec{3,T}); d₂ = zero(Vec{3,T})
     for I in 1:n_nodes
-        # Use the stored Float64 frame vectors directly; scalar·Vec promotion
-        # handles the Dual (AD) case. Wrapping in Vec{3,T}(Tuple(...)) boxes and
-        # allocates ~5 KB/QP, which dominates the bending-kernel churn.
+        # get sotred frame data for node I
         G₃_I = scv.G₃_elem[I]
         T₁_I = scv.T₁_elem[I]
         T₂_I = scv.T₂_elem[I]
+        # get rotation dofs for node I
         φ₁ = u_e[5I-1]; φ₂ = u_e[5I]
         cosθ, sincθ = _cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
+        # and compute Rodrigues interpolation
         d_I = cosθ*G₃_I + sincθ*(φ₁*T₁_I + φ₂*T₂_I)
         d  += scv.N[I, qp]       * d_I
         d₁ += scv.dNdξ[I, qp][1] * d_I

--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -49,9 +49,12 @@ end
 @inline function director_field(scv, qp, u_e::AbstractVector{T}, n_nodes) where T
     d = zero(Vec{3,T}); d₁ = zero(Vec{3,T}); d₂ = zero(Vec{3,T})
     for I in 1:n_nodes
-        G₃_I = Vec{3,T}(Tuple(scv.G₃_elem[I]))
-        T₁_I = Vec{3,T}(Tuple(scv.T₁_elem[I]))
-        T₂_I = Vec{3,T}(Tuple(scv.T₂_elem[I]))
+        # Use the stored Float64 frame vectors directly; scalar·Vec promotion
+        # handles the Dual (AD) case. Wrapping in Vec{3,T}(Tuple(...)) boxes and
+        # allocates ~5 KB/QP, which dominates the bending-kernel churn.
+        G₃_I = scv.G₃_elem[I]
+        T₁_I = scv.T₁_elem[I]
+        T₂_I = scv.T₂_elem[I]
         φ₁ = u_e[5I-1]; φ₂ = u_e[5I]
         cosθ, sincθ = _cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
         d_I = cosθ*G₃_I + sincθ*(φ₁*T₁_I + φ₂*T₂_I)
@@ -106,7 +109,7 @@ function membrane_residuals_KL!(re, scv::ShellCellValues, u_e::AbstractVector{T}
         a₁ = scv.A₁[qp] + Δa₁; a₂ = scv.A₂[qp] + Δa₂
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         N, _ = membrane_stress_and_tangent(mat, c_ms, scv.A_metric[qp],
-                   Vec{3}(Tuple(scv.A₁[qp])), Vec{3}(Tuple(scv.A₂[qp])), G₃)
+                   scv.A₁[qp], scv.A₂[qp], G₃)
         dΩ = scv.detJdV[qp]
         for I in 1:n_nodes
             ∂NI1, ∂NI2 = scv.dNdξ[I, qp]
@@ -134,7 +137,7 @@ function membrane_tangent_KL!(ke, scv::ShellCellValues, u_e::AbstractVector{T}, 
         a₁ = scv.A₁[qp] + Δa₁; a₂ = scv.A₂[qp] + Δa₂
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         N, C = membrane_stress_and_tangent(mat, c_ms, scv.A_metric[qp],
-                   Vec{3}(Tuple(scv.A₁[qp])), Vec{3}(Tuple(scv.A₂[qp])), G₃)
+                   scv.A₁[qp], scv.A₂[qp], G₃)
         dΩ = scv.detJdV[qp]
         for I in 1:n_nodes
             ∂NI1, ∂NI2 = scv.dNdξ[I, qp]
@@ -202,7 +205,7 @@ function bending_energy_KL(u_flat, scv::ShellCellValues, mat)
     W  = zero(T)
     G₃ = scv.G₃_elem[1]
     for qp in 1:getnquadpoints(scv)
-        A₁q = Vec{3}(Tuple(scv.A₁[qp])); A₂q = Vec{3}(Tuple(scv.A₂[qp]))
+        A₁q = scv.A₁[qp]; A₂q = scv.A₂[qp]
         a₁  = A₁q; a₂  = A₂q
         a₁₁ = Vec{3,T}(Tuple(scv.A₁₁[qp])); a₁₂ = Vec{3,T}(Tuple(scv.A₁₂[qp])); a₂₂ = Vec{3,T}(Tuple(scv.A₂₂[qp]))
         for I in 1:n_nodes
@@ -252,7 +255,7 @@ function membrane_residuals_RM!(re, scv::ShellCellValues, u_e::AbstractVector{T}
         a₁, a₂ = covariant_basis(scv, qp, u_e, n_nodes)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         N, _ = membrane_stress_and_tangent(mat, c_ms, scv.A_metric[qp],
-                   Vec{3}(Tuple(scv.A₁[qp])), Vec{3}(Tuple(scv.A₂[qp])), G₃)
+                   scv.A₁[qp], scv.A₂[qp], G₃)
         P₁ = N[1,1]*a₁ + N[1,2]*a₂
         P₂ = N[2,1]*a₁ + N[2,2]*a₂
         dΩ = scv.detJdV[qp]
@@ -309,7 +312,7 @@ function energy_RM(u_flat, scv::ShellCellValues, mat)
         γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         W += rm_qp_energy(mat, c_ms, κ, γ₁, γ₂, scv.A_metric[qp],
-                          Vec{3}(Tuple(scv.A₁[qp])), Vec{3}(Tuple(scv.A₂[qp])), d₀) * scv.detJdV[qp]
+                          scv.A₁[qp], scv.A₂[qp], d₀) * scv.detJdV[qp]
     end
     return W
 end
@@ -360,7 +363,7 @@ function membrane_tangent_RM!(ke, scv::ShellCellValues, u_e::AbstractVector{T}, 
         a₁, a₂ = covariant_basis(scv, qp, u_e, n_nodes)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         N, C = membrane_stress_and_tangent(mat, c_ms, scv.A_metric[qp],
-                   Vec{3}(Tuple(scv.A₁[qp])), Vec{3}(Tuple(scv.A₂[qp])), G₃)
+                   scv.A₁[qp], scv.A₂[qp], G₃)
         M₁₁, M₁₂, M₂₂ = frame_stiffness(C, a₁, a₂)
         dΩ = scv.detJdV[qp]
         for I in 1:n_nodes
@@ -407,7 +410,7 @@ function bending_residuals_RM!(re, scv::ShellCellValues, u_e::AbstractVector{T},
         γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp],
-                   Vec{3}(Tuple(scv.A₁[qp])), Vec{3}(Tuple(scv.A₂[qp])), d₀)
+                   scv.A₁[qp], scv.A₂[qp], d₀)
         M   = D ⊡ κ
         Q₁  = Cs[1,1]*γ₁ + Cs[1,2]*γ₂
         Q₂  = Cs[2,1]*γ₁ + Cs[2,2]*γ₂
@@ -456,11 +459,15 @@ function bending_tangent_RM!(ke, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::Abs
     n_nodes = getnbasefunctions(scv.ip_shape)
     Nt      = length(mitc.ξ_tie_1)
 
+    # Reusable scratch from the MITC object (overwritten here; not thread-safe).
+    a₁_tie = mitc.a₁_tie_s; a₂_tie = mitc.a₂_tie_s
+    d_tie1 = mitc.d_tie1_s; d_tie2 = mitc.d_tie2_s
+    dd1_J  = mitc.dd1_s;    dd2_J  = mitc.dd2_s
+    Bγ₁u   = mitc.Bγ₁u_s;   Bγ₂u   = mitc.Bγ₂u_s
+    Bγ₁φ1  = mitc.Bγ₁φ1_s;  Bγ₁φ2  = mitc.Bγ₁φ2_s
+    Bγ₂φ1  = mitc.Bγ₂φ1_s;  Bγ₂φ2  = mitc.Bγ₂φ2_s
+
     # Deformed tangents and interpolated directors at tying points (QP-independent).
-    a₁_tie = Vector{Vec{3,T}}(undef, Nt)
-    a₂_tie = Vector{Vec{3,T}}(undef, Nt)
-    d_tie1 = Vector{Vec{3,T}}(undef, Nt)
-    d_tie2 = Vector{Vec{3,T}}(undef, Nt)
     for k in 1:Nt
         Δa₁ = zero(Vec{3,T}); d_k1 = zero(Vec{3,T})
         for I in 1:n_nodes
@@ -468,11 +475,11 @@ function bending_tangent_RM!(ke, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::Abs
             Δa₁ += u_I * mitc.dNdξ_tie_1[I,k][1]
             φ₁ = u_e[5I-1]; φ₂ = u_e[5I]
             cosθ, sincθ = _cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
-            G₃_I = Vec{3,T}(mitc.G₃_node[I]); T₁_I = Vec{3,T}(mitc.T₁_node[I]); T₂_I = Vec{3,T}(mitc.T₂_node[I])
+            G₃_I = mitc.G₃_node[I]; T₁_I = mitc.T₁_node[I]; T₂_I = mitc.T₂_node[I]
             d_k1 += mitc.N_tie_1[I,k] * (cosθ*G₃_I + sincθ*(φ₁*T₁_I + φ₂*T₂_I))
         end
-        a₁_tie[k] = Vec{3,T}(mitc.A₁_tie_1[k]) + Δa₁
-        d_tie1[k]  = d_k1
+        a₁_tie[k] = mitc.A₁_tie_1[k] + Δa₁
+        d_tie1[k] = d_k1
     end
     for k in 1:Nt
         Δa₂ = zero(Vec{3,T}); d_k2 = zero(Vec{3,T})
@@ -481,39 +488,23 @@ function bending_tangent_RM!(ke, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::Abs
             Δa₂ += u_I * mitc.dNdξ_tie_2[I,k][2]
             φ₁ = u_e[5I-1]; φ₂ = u_e[5I]
             cosθ, sincθ = _cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
-            G₃_I = Vec{3,T}(mitc.G₃_node[I]); T₁_I = Vec{3,T}(mitc.T₁_node[I]); T₂_I = Vec{3,T}(mitc.T₂_node[I])
+            G₃_I = mitc.G₃_node[I]; T₁_I = mitc.T₁_node[I]; T₂_I = mitc.T₂_node[I]
             d_k2 += mitc.N_tie_2[I,k] * (cosθ*G₃_I + sincθ*(φ₁*T₁_I + φ₂*T₂_I))
         end
-        a₂_tie[k] = Vec{3,T}(mitc.A₂_tie_2[k]) + Δa₂
-        d_tie2[k]  = d_k2
+        a₂_tie[k] = mitc.A₂_tie_2[k] + Δa₂
+        d_tie2[k] = d_k2
     end
 
-    # Rodrigues Jacobians at tying points per node: ∂d_J/∂φ_l evaluated at tying-point geometry.
-    dd1_t1 = Matrix{Vec{3,T}}(undef, n_nodes, Nt)
-    dd2_t1 = Matrix{Vec{3,T}}(undef, n_nodes, Nt)
-    dd1_t2 = Matrix{Vec{3,T}}(undef, n_nodes, Nt)
-    dd2_t2 = Matrix{Vec{3,T}}(undef, n_nodes, Nt)
+    # Rodrigues Jacobian ∂d_J/∂φ_l per node J (uses tying-point reference frame,
+    # which is k-independent here, so a single value per node suffices).
     for J in 1:n_nodes
         φ₁_J = u_e[5J-1]; φ₂_J = u_e[5J]
-        G₃_J = Vec{3,T}(mitc.G₃_node[J]); T₁_J = Vec{3,T}(mitc.T₁_node[J]); T₂_J = Vec{3,T}(mitc.T₂_node[J])
+        G₃_J = mitc.G₃_node[J]; T₁_J = mitc.T₁_node[J]; T₂_J = mitc.T₂_node[J]
         _, _, dd1, dd2 = rodrigues_jac(φ₁_J, φ₂_J, G₃_J, T₁_J, T₂_J)
-        for k in 1:Nt
-            dd1_t1[J,k] = dd1; dd2_t1[J,k] = dd2
-        end
-        for k in 1:Nt
-            dd1_t2[J,k] = dd1; dd2_t2[J,k] = dd2
-        end
+        dd1_J[J] = dd1; dd2_J[J] = dd2
     end
 
     γ₁_k, γ₂_k = tying_shear_strains(mitc, u_e)
-
-    # Per-QP workspace: MITC shear sensitivities
-    Bγ₁u  = Vector{Vec{3,T}}(undef, n_nodes)
-    Bγ₂u  = Vector{Vec{3,T}}(undef, n_nodes)
-    Bγ₁φ1 = Vector{T}(undef, n_nodes)
-    Bγ₁φ2 = Vector{T}(undef, n_nodes)
-    Bγ₂φ1 = Vector{T}(undef, n_nodes)
-    Bγ₂φ2 = Vector{T}(undef, n_nodes)
 
     for qp in 1:getnquadpoints(scv)
         a₁, a₂ = covariant_basis(scv, qp, u_e, n_nodes)
@@ -524,7 +515,7 @@ function bending_tangent_RM!(ke, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::Abs
         γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp],
-                   Vec{3}(Tuple(scv.A₁[qp])), Vec{3}(Tuple(scv.A₂[qp])), d₀)
+                   scv.A₁[qp], scv.A₂[qp], d₀)
         Mb  = D ⊡ κ
         Q₁  = Cs[1,1]*γ₁ + Cs[1,2]*γ₂
         Q₂  = Cs[2,1]*γ₁ + Cs[2,2]*γ₂
@@ -542,10 +533,10 @@ function bending_tangent_RM!(ke, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::Abs
                 h1 = mitc.h_tie_1[qp,k]; h2 = mitc.h_tie_2[qp,k]
                 Bγ₁u[J]  += h1 * mitc.dNdξ_tie_1[J,k][1] * d_tie1[k]
                 Bγ₂u[J]  += h2 * mitc.dNdξ_tie_2[J,k][2] * d_tie2[k]
-                Bγ₁φ1[J] += h1 * mitc.N_tie_1[J,k] * dot(a₁_tie[k], dd1_t1[J,k])
-                Bγ₁φ2[J] += h1 * mitc.N_tie_1[J,k] * dot(a₁_tie[k], dd2_t1[J,k])
-                Bγ₂φ1[J] += h2 * mitc.N_tie_2[J,k] * dot(a₂_tie[k], dd1_t2[J,k])
-                Bγ₂φ2[J] += h2 * mitc.N_tie_2[J,k] * dot(a₂_tie[k], dd2_t2[J,k])
+                Bγ₁φ1[J] += h1 * mitc.N_tie_1[J,k] * dot(a₁_tie[k], dd1_J[J])
+                Bγ₁φ2[J] += h1 * mitc.N_tie_1[J,k] * dot(a₁_tie[k], dd2_J[J])
+                Bγ₂φ1[J] += h2 * mitc.N_tie_2[J,k] * dot(a₂_tie[k], dd1_J[J])
+                Bγ₂φ2[J] += h2 * mitc.N_tie_2[J,k] * dot(a₂_tie[k], dd2_J[J])
             end
         end
 
@@ -624,7 +615,7 @@ function bending_tangent_RM!(ke, scv::ShellCellValues, u_e::AbstractVector{T}, m
         γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp],
-                   Vec{3}(Tuple(scv.A₁[qp])), Vec{3}(Tuple(scv.A₂[qp])), d₀)
+                   scv.A₁[qp], scv.A₂[qp], d₀)
         M   = D ⊡ κ
         Q₁  = Cs[1,1]*γ₁ + Cs[1,2]*γ₂
         Q₂  = Cs[2,1]*γ₁ + Cs[2,2]*γ₂

--- a/src/material.jl
+++ b/src/material.jl
@@ -26,7 +26,10 @@ function membrane_stress_and_tangent(mat::LinearElastic, c_ms::SymmetricTensor{2
     Aup = inv(A_metric)
     μ = mat.E * mat.thickness / (2*(1 + mat.ν))
     λ = mat.ν * mat.thickness * mat.E / (1 - mat.ν^2)
-    C = SymmetricTensor{4,2,T}((α,β,γ,δ) -> λ*Aup[α,β]*Aup[γ,δ] + μ*(Aup[α,γ]*Aup[β,δ] + Aup[α,δ]*Aup[β,γ]))
+    # C^{αβγδ} = λ Aup^{αβ} Aup^{γδ} + μ (Aup^{αγ} Aup^{βδ} + Aup^{αδ} Aup^{βγ})
+    # built with non-capturing tensor algebra (otimesu/otimesl) to avoid the
+    # heap allocation of the closure-based SymmetricTensor constructor.
+    C = λ * (Aup ⊗ Aup) + μ * symmetric(otimesu(Aup, Aup) + otimesl(Aup, Aup))
     return C ⊡ ((c_ms - A_metric) / 2), C
 end
 

--- a/src/material.jl
+++ b/src/material.jl
@@ -27,8 +27,6 @@ function membrane_stress_and_tangent(mat::LinearElastic, c_ms::SymmetricTensor{2
     μ = mat.E * mat.thickness / (2*(1 + mat.ν))
     λ = mat.ν * mat.thickness * mat.E / (1 - mat.ν^2)
     # C^{αβγδ} = λ Aup^{αβ} Aup^{γδ} + μ (Aup^{αγ} Aup^{βδ} + Aup^{αδ} Aup^{βγ})
-    # built with non-capturing tensor algebra (otimesu/otimesl) to avoid the
-    # heap allocation of the closure-based SymmetricTensor constructor.
     C = λ * (Aup ⊗ Aup) + μ * symmetric(otimesu(Aup, Aup) + otimesl(Aup, Aup))
     return C ⊡ ((c_ms - A_metric) / 2), C
 end

--- a/src/mitc.jl
+++ b/src/mitc.jl
@@ -25,6 +25,13 @@ struct MITC{N,M,T<:AbstractFloat} <: AbstractMITC
     G₃_node :: Vector{Vec{3,T}}   # per-element-local-node frame (length N)
     T₁_node :: Vector{Vec{3,T}}
     T₂_node :: Vector{Vec{3,T}}
+    # Reusable scratch for bending_tangent_RM! (overwritten each call; not thread-safe).
+    a₁_tie_s :: Vector{Vec{3,T}}; a₂_tie_s :: Vector{Vec{3,T}}   # length M (tying points)
+    d_tie1_s :: Vector{Vec{3,T}}; d_tie2_s :: Vector{Vec{3,T}}
+    dd1_s    :: Vector{Vec{3,T}}; dd2_s    :: Vector{Vec{3,T}}   # length N (nodes), Rodrigues ∂d/∂φ
+    Bγ₁u_s   :: Vector{Vec{3,T}}; Bγ₂u_s   :: Vector{Vec{3,T}}   # length N
+    Bγ₁φ1_s  :: Vector{T}; Bγ₁φ2_s :: Vector{T}
+    Bγ₂φ1_s  :: Vector{T}; Bγ₂φ2_s :: Vector{T}
 end
 function MITC{N}(ip_shape::Interpolation, h_tie_1, h_tie_2, ξ_tie_1, ξ_tie_2) where N
     n_shape = getnbasefunctions(ip_shape)
@@ -52,6 +59,12 @@ function MITC{N}(ip_shape::Interpolation, h_tie_1, h_tie_2, ξ_tie_1, ξ_tie_2) 
         fill(zero(Vec{3,T}), Nt), fill(zero(Vec{3,T}), Nt), fill(zero(Vec{3,T}), Nt),
         ξ_tie_1, ξ_tie_2,
         fill(zero(Vec{3,T}), N), fill(zero(Vec{3,T}), N), fill(zero(Vec{3,T}), N),
+        Vector{Vec{3,T}}(undef, Nt), Vector{Vec{3,T}}(undef, Nt),
+        Vector{Vec{3,T}}(undef, Nt), Vector{Vec{3,T}}(undef, Nt),
+        Vector{Vec{3,T}}(undef, N),  Vector{Vec{3,T}}(undef, N),
+        Vector{Vec{3,T}}(undef, N),  Vector{Vec{3,T}}(undef, N),
+        Vector{T}(undef, N), Vector{T}(undef, N),
+        Vector{T}(undef, N), Vector{T}(undef, N),
     )
 end
 

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -1,0 +1,76 @@
+# Standalone allocation-regression check for the hot RM/MITC element kernels.
+# NOT part of the test suite (not included from test/runtests.jl) — run it directly:
+#
+#   julia --project test/test_allocations.jl
+#
+# Rationale: the per-cell assembly kernels are called millions of times in the
+# dynamic/inflation drivers, so heap allocation there drives GC working-set growth
+# (and OOM on large meshes). These bounds catch regressions such as the
+# `Vec{3,T}(Tuple(scv.G₃_elem[I]))` boxing that previously cost ~5 KB/QP in
+# `director_field`, or a closure-built material tangent.
+#
+# Everything runs inside `run_alloc_tests()` so the measured closures capture
+# *local* variables (top-level captures are type-unstable and allocate spuriously).
+
+using FerriteShells, LinearAlgebra, Test
+import FerriteShells: covariant_basis, director_field
+
+# Measure allocations of a zero-arg thunk after warm-up (compile first, then
+# measure a steady call so we time the kernel, not JIT).
+function alloc_of(f)
+    f(); f()
+    @allocated f()
+end
+
+# Per-QP helper loops (function barrier so we measure the loop body, not the
+# dynamic call boundary). director_field/covariant_basis must be allocation-free.
+loop_director(scv, u_e, n_nodes, n_qp) =
+    (s = zero(Vec{3,Float64}); for qp in 1:n_qp; d, d₁, d₂ = director_field(scv, qp, u_e, n_nodes); s += d + d₁ + d₂; end; s)
+loop_covariant(scv, u_e, n_nodes, n_qp) =
+    (s = zero(Vec{3,Float64}); for qp in 1:n_qp; a₁, a₂ = covariant_basis(scv, qp, u_e, n_nodes); s += a₁ + a₂; end; s)
+
+function run_alloc_tests()
+    # Q9 + MITC9 unit element (mirrors make_q9_scv from the test suite).
+    grid = shell_grid(generate_grid(QuadraticQuadrilateral, (2, 2)))
+    ip   = Lagrange{RefQuadrilateral, 2}()
+    qr   = QuadratureRule{RefQuadrilateral}(3)
+    scv  = ShellCellValues(qr, ip, ip; mitc=MITC9)
+    dh   = DofHandler(grid)
+    add!(dh, :u, ip^3); add!(dh, :θ, ip^2); close!(dh)
+    mat  = LinearElastic(0.35e6, 0.3, 0.0002)
+
+    reinit!(scv, first(CellIterator(dh)))
+    n_e     = ndofs_per_cell(dh)
+    n_nodes = getnbasefunctions(scv.ip_shape)
+    n_qp    = getnquadpoints(scv)
+    u_e     = 0.001 .* randn(n_e)
+    ke      = zeros(n_e, n_e)
+    re      = zeros(n_e)
+
+    @testset "element kernel allocations (Q9 + MITC9, LinearElastic)" begin
+        # Per-QP geometry helpers: must allocate nothing.
+        @test alloc_of(() -> loop_director(scv, u_e, n_nodes, n_qp))  == 0
+        @test alloc_of(() -> loop_covariant(scv, u_e, n_nodes, n_qp)) == 0
+
+        # Follower-pressure kernels are already allocation-free.
+        @test alloc_of(() -> assemble_pressure!(re, scv, u_e, 1.0))         == 0
+        @test alloc_of(() -> assemble_pressure_tangent!(ke, scv, u_e, 1.0)) == 0
+
+        # Residual/tangent kernels are fully allocation-free: geometry helpers use
+        # the stored Float64 frames directly (no Tuple boxing) and the MITC tangent
+        # reuses scratch buffers held in the MITC object. Were ~5.6 KB (membrane/
+        # residual) and ~52–60 KB (bending) before those fixes.
+        @test alloc_of(() -> membrane_residuals_RM!(re, scv, u_e, mat)) == 0
+        @test alloc_of(() -> bending_residuals_RM!(re, scv, u_e, mat))  == 0
+        @test alloc_of(() -> membrane_tangent_RM!(ke, scv, u_e, mat))   == 0
+        @test alloc_of(() -> bending_tangent_RM!(ke, scv, u_e, mat))    == 0
+
+        # A full per-cell assembly sweep (all four kernels) — also allocation-free.
+        full() = (fill!(ke, 0.0); fill!(re, 0.0);
+                  membrane_residuals_RM!(re, scv, u_e, mat); bending_residuals_RM!(re, scv, u_e, mat);
+                  membrane_tangent_RM!(ke, scv, u_e, mat);   bending_tangent_RM!(ke, scv, u_e, mat))
+        @test alloc_of(full) == 0
+    end
+end
+
+run_alloc_tests()

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -1,16 +1,6 @@
-# Standalone allocation-regression check for the hot RM/MITC element kernels.
-# NOT part of the test suite (not included from test/runtests.jl) — run it directly:
+# Standalone allocation-regression check — run it directly:
 #
 #   julia --project test/test_allocations.jl
-#
-# Rationale: the per-cell assembly kernels are called millions of times in the
-# dynamic/inflation drivers, so heap allocation there drives GC working-set growth
-# (and OOM on large meshes). These bounds catch regressions such as the
-# `Vec{3,T}(Tuple(scv.G₃_elem[I]))` boxing that previously cost ~5 KB/QP in
-# `director_field`, or a closure-built material tangent.
-#
-# Everything runs inside `run_alloc_tests()` so the measured closures capture
-# *local* variables (top-level captures are type-unstable and allocate spuriously).
 
 using FerriteShells, LinearAlgebra, Test
 import FerriteShells: covariant_basis, director_field
@@ -24,53 +14,71 @@ end
 
 # Per-QP helper loops (function barrier so we measure the loop body, not the
 # dynamic call boundary). director_field/covariant_basis must be allocation-free.
-loop_director(scv, u_e, n_nodes, n_qp) =
-    (s = zero(Vec{3,Float64}); for qp in 1:n_qp; d, d₁, d₂ = director_field(scv, qp, u_e, n_nodes); s += d + d₁ + d₂; end; s)
-loop_covariant(scv, u_e, n_nodes, n_qp) =
-    (s = zero(Vec{3,Float64}); for qp in 1:n_qp; a₁, a₂ = covariant_basis(scv, qp, u_e, n_nodes); s += a₁ + a₂; end; s)
+function loop_director(scv, u_e, n_nodes, n_qp)
+    s = zero(Vec{3,Float64})
+    for qp in 1:n_qp
+        d, d₁, d₂ = director_field(scv, qp, u_e, n_nodes)
+        s += d + d₁ + d₂
+    end
+    s
+end
+function loop_covariant(scv, u_e, n_nodes, n_qp)
+    s = zero(Vec{3,Float64})
+    for qp in 1:n_qp
+        a₁, a₂ = covariant_basis(scv, qp, u_e, n_nodes)
+        s += a₁ + a₂
+    end
+    s
+end
 
-function run_alloc_tests()
-    # Q9 + MITC9 unit element (mirrors make_q9_scv from the test suite).
-    grid = shell_grid(generate_grid(QuadraticQuadrilateral, (2, 2)))
-    ip   = Lagrange{RefQuadrilateral, 2}()
-    qr   = QuadratureRule{RefQuadrilateral}(3)
-    scv  = ShellCellValues(qr, ip, ip; mitc=MITC9)
-    dh   = DofHandler(grid)
-    add!(dh, :u, ip^3); add!(dh, :θ, ip^2); close!(dh)
-    mat  = LinearElastic(0.35e6, 0.3, 0.0002)
+# elements
+elements = ((Quadrilateral, RefQuadrilateral, 1, MITC4),
+            (QuadraticQuadrilateral, RefQuadrilateral, 2, MITC9))
 
-    reinit!(scv, first(CellIterator(dh)))
-    n_e     = ndofs_per_cell(dh)
-    n_nodes = getnbasefunctions(scv.ip_shape)
-    n_qp    = getnquadpoints(scv)
-    u_e     = 0.001 .* randn(n_e)
-    ke      = zeros(n_e, n_e)
-    re      = zeros(n_e)
-
-    @testset "element kernel allocations (Q9 + MITC9, LinearElastic)" begin
+@testset "Element kernel allocations" begin
+   for elem in elements
+        (Q,R,O,M) = elem # unpack
+        # unit element
+        grid     = shell_grid(generate_grid(Q, (2, 2)))
+        ip       = Lagrange{R, O}()
+        qr       = QuadratureRule{R}(O+1)
+        fqr      = FacetQuadratureRule{R}(O+1)
+        scv_mitc = ShellCellValues(qr, ip, ip; mitc=M)
+        scv      = ShellCellValues(qr, ip, ip)
+        # dofs and material
+        dh = DofHandler(grid)
+        add!(dh, :u, ip^3); add!(dh, :θ, ip^2); close!(dh)
+        mat  = LinearElastic(1.0e6, 0.3, 0.1)
+        # update to match first cell
+        reinit!(scv_mitc, first(CellIterator(dh)))
+        n_e     = ndofs_per_cell(dh)
+        n_nodes = getnbasefunctions(scv_mitc.ip_shape)
+        n_qp    = getnquadpoints(scv_mitc)
+        u_e     = 0.001 .* randn(n_e)
+        ke      = zeros(n_e, n_e)
+        re      = zeros(n_e)
+        f_ext   = zeros(ndofs(dh))
         # Per-QP geometry helpers: must allocate nothing.
-        @test alloc_of(() -> loop_director(scv, u_e, n_nodes, n_qp))  == 0
-        @test alloc_of(() -> loop_covariant(scv, u_e, n_nodes, n_qp)) == 0
-
-        # Follower-pressure kernels are already allocation-free.
-        @test alloc_of(() -> assemble_pressure!(re, scv, u_e, 1.0))         == 0
-        @test alloc_of(() -> assemble_pressure_tangent!(ke, scv, u_e, 1.0)) == 0
-
-        # Residual/tangent kernels are fully allocation-free: geometry helpers use
-        # the stored Float64 frames directly (no Tuple boxing) and the MITC tangent
-        # reuses scratch buffers held in the MITC object. Were ~5.6 KB (membrane/
-        # residual) and ~52–60 KB (bending) before those fixes.
-        @test alloc_of(() -> membrane_residuals_RM!(re, scv, u_e, mat)) == 0
-        @test alloc_of(() -> bending_residuals_RM!(re, scv, u_e, mat))  == 0
-        @test alloc_of(() -> membrane_tangent_RM!(ke, scv, u_e, mat))   == 0
+        @test alloc_of(() -> loop_director(scv_mitc, u_e, n_nodes, n_qp))  == 0
+        @test alloc_of(() -> loop_covariant(scv_mitc, u_e, n_nodes, n_qp)) == 0
+        # Follower-pressure kernels
+        @test alloc_of(() -> assemble_pressure!(re, scv_mitc, u_e, 1.0))         == 0
+        @test alloc_of(() -> assemble_pressure_tangent!(ke, scv_mitc, u_e, 1.0)) == 0
+        # test other external loading function
+        @test alloc_of(() ->assemble_traction!(f_ext, dh, getfacetset(grid, "left"), ip, fqr, Vec{3}((0.,0.,1.)))) != 0
+        # mass matrix, although it's usually used once...
+        @test alloc_of(() -> mass_matrix!(ke, scv_mitc, 1.0, mat)) == 0
+        # Residual/tangent kernels
+        @test alloc_of(() -> membrane_residuals_RM!(re, scv_mitc, u_e, mat)) == 0
+        @test alloc_of(() -> bending_residuals_RM!(re, scv_mitc, u_e, mat))  == 0
+        @test alloc_of(() -> membrane_tangent_RM!(ke, scv_mitc, u_e, mat))   == 0
+        @test alloc_of(() -> bending_tangent_RM!(ke, scv_mitc, u_e, mat))    == 0
+        # non MITC case
         @test alloc_of(() -> bending_tangent_RM!(ke, scv, u_e, mat))    == 0
-
         # A full per-cell assembly sweep (all four kernels) — also allocation-free.
         full() = (fill!(ke, 0.0); fill!(re, 0.0);
-                  membrane_residuals_RM!(re, scv, u_e, mat); bending_residuals_RM!(re, scv, u_e, mat);
-                  membrane_tangent_RM!(ke, scv, u_e, mat);   bending_tangent_RM!(ke, scv, u_e, mat))
+                  membrane_residuals_RM!(re, scv_mitc, u_e, mat); bending_residuals_RM!(re, scv_mitc, u_e, mat);
+                  membrane_tangent_RM!(ke, scv_mitc, u_e, mat);   bending_tangent_RM!(ke, scv_mitc, u_e, mat))
         @test alloc_of(full) == 0
     end
 end
-
-run_alloc_tests()

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -40,6 +40,7 @@ elements = ((Quadrilateral, RefQuadrilateral, 1, MITC4),
         (Q,R,O,M) = elem # unpack
         # unit element
         grid     = shell_grid(generate_grid(Q, (2, 2)))
+        addnodeset!(grid, "all", x->true)
         ip       = Lagrange{R, O}()
         qr       = QuadratureRule{R}(O+1)
         fqr      = FacetQuadratureRule{R}(O+1)
@@ -64,8 +65,9 @@ elements = ((Quadrilateral, RefQuadrilateral, 1, MITC4),
         # Follower-pressure kernels
         @test alloc_of(() -> assemble_pressure!(re, scv_mitc, u_e, 1.0))         == 0
         @test alloc_of(() -> assemble_pressure_tangent!(ke, scv_mitc, u_e, 1.0)) == 0
-        # test other external loading function
+        # test other external loading function TODO fix these two
         @test alloc_of(() ->assemble_traction!(f_ext, dh, getfacetset(grid, "left"), ip, fqr, Vec{3}((0.,0.,1.)))) != 0
+        @test alloc_of(() -> apply_pointload!(f_ext, dh, "all", Vec{3}((0.,0.,1.)))) != 0
         # mass matrix, although it's usually used once...
         @test alloc_of(() -> mass_matrix!(ke, scv_mitc, 1.0, mat)) == 0
         # Residual/tangent kernels
@@ -74,7 +76,7 @@ elements = ((Quadrilateral, RefQuadrilateral, 1, MITC4),
         @test alloc_of(() -> membrane_tangent_RM!(ke, scv_mitc, u_e, mat))   == 0
         @test alloc_of(() -> bending_tangent_RM!(ke, scv_mitc, u_e, mat))    == 0
         # non MITC case
-        @test alloc_of(() -> bending_tangent_RM!(ke, scv, u_e, mat))    == 0
+        @test alloc_of(() -> bending_tangent_RM!(ke, scv, u_e, mat)) == 0
         # A full per-cell assembly sweep (all four kernels) — also allocation-free.
         full() = (fill!(ke, 0.0); fill!(re, 0.0);
                   membrane_residuals_RM!(re, scv_mitc, u_e, mat); bending_residuals_RM!(re, scv_mitc, u_e, mat);


### PR DESCRIPTION
Adds scratch arrays to the `MITC` structure to avoid large allocations when the assembly functions are called.

Effectively drops all allocation in the assembly procedure. 