### PR TITLE
Fix non-conservative MITC shear residual/tangent on curved elements

### DIFF
--- a/docs/src/ReissnerMindlin.md
+++ b/docs/src/ReissnerMindlin.md
@@ -123,6 +123,10 @@ where ``S^\alpha = M^{\alpha\beta}\mathbf{d}_{,\beta}``.
 
 In FerriteShells the explicit forms are implemented in [`membrane_residuals_RM!`](@ref) and [`bending_residuals_RM!`](@ref). ForwardDiff-based residuals are also available as [`residuals_RM_FD!`](@ref) for both membrane, bending and shear contributions.
 
+!!! note
+    The advantage of the ForwardDiff-based residuals and tangents is that they are exact gradient and hessian of the internal energy, the explicit version should be as well but any small bug might break the energy consistency and lead to non-convergence of Newton-Raphson procedures. The explicit version is faster, but the ForwardDiff version is more robust, so it can be used as a reference to test the explicit version if you suspect an error in the explicit functions.
+
+
 ### 2.2 Consistent tangent and second variation
 
 The consistent tangent is the second variation of ``\mathcal{W}_\text{int}``. It has four blocks per node pair ``(I,J)``:

--- a/examples/SlitAnnularPlate.jl
+++ b/examples/SlitAnnularPlate.jl
@@ -29,7 +29,6 @@ function slit_annular_grid(a, b, n_r, n_q)
     return shell_grid(grid)                    # embed the planar Q9 grid into 3D (z = 0)
 end
 
-# Residual + tangent via ForwardDiff on energy_RM, required because theexplciit MITC variant is assymetric
 function assemble_global!(K, r, dh, scv, u, mat)
     n_e = ndofs_per_cell(dh); ke = zeros(n_e, n_e); re = zeros(n_e)
     asm = start_assemble(K, r)
@@ -37,8 +36,10 @@ function assemble_global!(K, r, dh, scv, u, mat)
         fill!(ke, 0.0); fill!(re, 0.0)
         reinit!(scv, cell)
         u_e = u[shelldofs(cell)]
-        residuals_RM_FD!(re, scv, u_e, mat)
-        tangent_RM_FD!(ke, scv, u_e, mat)
+        membrane_tangent_RM!(ke, scv, u_e, mat)
+        membrane_residuals_RM!(re, scv, u_e, mat)
+        bending_tangent_RM!(ke, scv, u_e, mat)
+        bending_residuals_RM!(re, scv, u_e, mat)
         assemble!(asm, shelldofs(cell), ke, re)
     end
 end

--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -4,7 +4,7 @@ using ForwardDiff
 # ForwardDiff-safe: the branch is on the primal value only, so dual perturbations
 # flow through whichever branch is active.  In the else branch √θ² > 0 so the
 # sqrt gradient (1/2√θ²) is finite.
-@inline function _cos_sinc_sq(θ²::T) where T
+@inline function cos_sinc_sq(θ²::T) where T
     if θ² < 1e-6
         return one(T) - θ²/2 + θ²^2/24,  one(T) - θ²/6 + θ²^2/120
     else
@@ -16,7 +16,7 @@ end
 # Returns (cosθ, sinc(θ), s_cc) where s_cc = (cosθ - sinc(θ))/θ².
 # s_cc is the coefficient in ∂d_I/∂φ_k (Rodrigues director Jacobian).
 # Taylor at θ²→0: s_cc → -1/3 + θ²/30. ForwardDiff-safe: branch on primal only.
-@inline function _cos_sinc_sincc_sq(θ²::T) where T
+@inline function cos_sinc_sincc_sq(θ²::T) where T
     if θ² < 1e-6
         cosθ  = one(T) - θ²/2  + θ²^2/24
         sincθ = one(T) - θ²/6  + θ²^2/120
@@ -55,7 +55,7 @@ end
         T₂_I = scv.T₂_elem[I]
         # get rotation dofs for node I
         φ₁ = u_e[5I-1]; φ₂ = u_e[5I]
-        cosθ, sincθ = _cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
+        cosθ, sincθ = cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
         # and compute Rodrigues interpolation
         d_I = cosθ*G₃_I + sincθ*(φ₁*T₁_I + φ₂*T₂_I)
         d  += scv.N[I, qp]       * d_I
@@ -86,10 +86,19 @@ end
 # Rodrigues director Jacobian ∂d_I/∂φ₁ and ∂d_I/∂φ₂ at a single node.
 # Returns (sincθ, sccθ, dd₁, dd₂); sincθ/sccθ are reused in the tangent's geometric block.
 @inline function rodrigues_jac(φ₁, φ₂, G₃, T₁, T₂)
-    _, sincθ, sccθ = _cos_sinc_sincc_sq(φ₁*φ₁ + φ₂*φ₂)
+    _, sincθ, sccθ = cos_sinc_sincc_sq(φ₁*φ₁ + φ₂*φ₂)
     dd₁ = (sincθ + sccθ*φ₁^2)*T₁ + sccθ*φ₁*φ₂*T₂ - sincθ*φ₁*G₃
     dd₂ = sccθ*φ₁*φ₂*T₁ + (sincθ + sccθ*φ₂^2)*T₂ - sincθ*φ₂*G₃
     sincθ, sccθ, dd₁, dd₂
+end
+
+# Second derivatives of the Rodrigues director d(φ) w.r.t. (φ₁,φ₂): returns
+# (∂²d/∂φ₁², ∂²d/∂φ₁∂φ₂, ∂²d/∂φ₂²). `s`=sinc, `sc`=scc, `sccc`=(-s-3sc)/θ² (Taylor 1/15).
+@inline function rodrigues_hess(s, sc, sccc, φ₁, φ₂, G₃, T₁, T₂)
+    d2_11 = (3sc*φ₁ + sccc*φ₁^3)*T₁ + (sc + sccc*φ₁^2)*φ₂*T₂ - (s + sc*φ₁^2)*G₃
+    d2_12 = (sc + sccc*φ₁^2)*φ₂*T₁ + (sc + sccc*φ₂^2)*φ₁*T₂ - sc*φ₁*φ₂*G₃
+    d2_22 = (sc + sccc*φ₂^2)*φ₁*T₁ + (3sc*φ₂ + sccc*φ₂^3)*T₂ - (s + sc*φ₂^2)*G₃
+    d2_11, d2_12, d2_22
 end
 
 """
@@ -430,6 +439,79 @@ function bending_residuals_RM!(re, scv::ShellCellValues, u_e::AbstractVector{T},
     end
 end
 
+# MITC dispatch: the assumed-shear residual must vary the *tying-interpolated* strain,
+# i.e. use the MITC B-operators ∂γ_α/∂u (Bγ), not the QP-direct ∂N·d / N·a·dd used above.
+# Only then is the residual the exact gradient of energy_RM (conservative ⇒ symmetric
+# tangent). The QP-direct variant is only ~O(1%) accurate and non-symmetric on curved
+# elements. Bending (κ/D) terms are QP-direct as in the NoMITC path.
+function bending_residuals_RM!(re, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::AbstractVector{T}, mat) where {QR,IPG,IPS,FT<:AbstractFloat,M<:MITC,T}
+    mitc    = scv.mitc
+    n_nodes = getnbasefunctions(scv.ip_shape)
+    Nt      = length(mitc.ξ_tie_1)
+
+    a₁_tie = Vector{Vec{3,T}}(undef, Nt); d_tie1 = Vector{Vec{3,T}}(undef, Nt)
+    a₂_tie = Vector{Vec{3,T}}(undef, Nt); d_tie2 = Vector{Vec{3,T}}(undef, Nt)
+    for k in 1:Nt
+        Δa₁ = zero(Vec{3,T}); dk1 = zero(Vec{3,T})
+        Δa₂ = zero(Vec{3,T}); dk2 = zero(Vec{3,T})
+        for I in 1:n_nodes
+            u_I = Vec{3,T}((u_e[5I-4], u_e[5I-3], u_e[5I-2]))
+            Δa₁ += u_I * mitc.dNdξ_tie_1[I,k][1]
+            Δa₂ += u_I * mitc.dNdξ_tie_2[I,k][2]
+            φ₁ = u_e[5I-1]; φ₂ = u_e[5I]; cosθ, sincθ = cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
+            dI = cosθ*mitc.G₃_node[I] + sincθ*(φ₁*mitc.T₁_node[I] + φ₂*mitc.T₂_node[I])
+            dk1 += mitc.N_tie_1[I,k] * dI
+            dk2 += mitc.N_tie_2[I,k] * dI
+        end
+        a₁_tie[k] = mitc.A₁_tie_1[k] + Δa₁; d_tie1[k] = dk1
+        a₂_tie[k] = mitc.A₂_tie_2[k] + Δa₂; d_tie2[k] = dk2
+    end
+    dd1n = Vector{Vec{3,T}}(undef, n_nodes); dd2n = Vector{Vec{3,T}}(undef, n_nodes)
+    for I in 1:n_nodes
+        _, _, d1, d2 = rodrigues_jac(u_e[5I-1], u_e[5I], mitc.G₃_node[I], mitc.T₁_node[I], mitc.T₂_node[I])
+        dd1n[I] = d1; dd2n[I] = d2
+    end
+
+    γ₁_k, γ₂_k = tying_shear_strains(mitc, u_e)
+    for qp in 1:getnquadpoints(scv)
+        a₁, a₂ = covariant_basis(scv, qp, u_e, n_nodes)
+        d, d₁, d₂ = director_field(scv, qp, u_e, n_nodes)
+        κ   = curvature_tensor(a₁, a₂, d₁, d₂, scv.B[qp])
+        γ₁, γ₂ = shear_strains(a₁, a₂, d, qp, γ₁_k, γ₂_k, mitc)
+        d₀  = reference_director(scv, qp, n_nodes)
+        γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
+        c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
+        D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp], scv.A₁[qp], scv.A₂[qp], d₀)
+        Mb  = D ⊡ κ
+        Q₁  = Cs[1,1]*γ₁ + Cs[1,2]*γ₂
+        Q₂  = Cs[2,1]*γ₁ + Cs[2,2]*γ₂
+        Pb¹ = Mb[1,1]*d₁ + Mb[1,2]*d₂            # bending only (shear added via Bγ)
+        Pb² = Mb[2,1]*d₁ + Mb[2,2]*d₂
+        S¹  = Mb[1,1]*a₁ + Mb[1,2]*a₂
+        S²  = Mb[2,1]*a₁ + Mb[2,2]*a₂
+        dΩ  = scv.detJdV[qp]
+        for I in 1:n_nodes
+            ∂NI1, ∂NI2 = scv.dNdξ[I, qp]
+            Bγ1u = zero(Vec{3,T}); Bγ2u = zero(Vec{3,T})
+            Bγ1φ1 = zero(T); Bγ1φ2 = zero(T); Bγ2φ1 = zero(T); Bγ2φ2 = zero(T)
+            @inbounds for k in 1:Nt
+                h1 = mitc.h_tie_1[qp,k]; h2 = mitc.h_tie_2[qp,k]
+                Bγ1u  += h1 * mitc.dNdξ_tie_1[I,k][1] * d_tie1[k]
+                Bγ2u  += h2 * mitc.dNdξ_tie_2[I,k][2] * d_tie2[k]
+                Bγ1φ1 += h1 * mitc.N_tie_1[I,k] * dot(a₁_tie[k], dd1n[I])
+                Bγ1φ2 += h1 * mitc.N_tie_1[I,k] * dot(a₁_tie[k], dd2n[I])
+                Bγ2φ1 += h2 * mitc.N_tie_2[I,k] * dot(a₂_tie[k], dd1n[I])
+                Bγ2φ2 += h2 * mitc.N_tie_2[I,k] * dot(a₂_tie[k], dd2n[I])
+            end
+            @views re[5I-4:5I-2] .+= (∂NI1*Pb¹ + ∂NI2*Pb² + Q₁*Bγ1u + Q₂*Bγ2u) * dΩ
+            _, _, dd_I1, dd_I2 = rodrigues_jac(u_e[5I-1], u_e[5I], scv.G₃_elem[I], scv.T₁_elem[I], scv.T₂_elem[I])
+            Fb_I = ∂NI1*S¹ + ∂NI2*S²
+            re[5I-1] += (dot(Fb_I, dd_I1) + Q₁*Bγ1φ1 + Q₂*Bγ2φ1) * dΩ
+            re[5I  ] += (dot(Fb_I, dd_I2) + Q₁*Bγ1φ2 + Q₂*Bγ2φ2) * dΩ
+        end
+    end
+end
+
 """
     bending_tangent_RM!(ke, scv, u_e, mat)  [MITC dispatch]
 
@@ -472,7 +554,7 @@ function bending_tangent_RM!(ke, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::Abs
             u_I = Vec{3,T}((u_e[5I-4], u_e[5I-3], u_e[5I-2]))
             Δa₁ += u_I * mitc.dNdξ_tie_1[I,k][1]
             φ₁ = u_e[5I-1]; φ₂ = u_e[5I]
-            cosθ, sincθ = _cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
+            cosθ, sincθ = cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
             G₃_I = mitc.G₃_node[I]; T₁_I = mitc.T₁_node[I]; T₂_I = mitc.T₂_node[I]
             d_k1 += mitc.N_tie_1[I,k] * (cosθ*G₃_I + sincθ*(φ₁*T₁_I + φ₂*T₂_I))
         end
@@ -485,7 +567,7 @@ function bending_tangent_RM!(ke, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::Abs
             u_I = Vec{3,T}((u_e[5I-4], u_e[5I-3], u_e[5I-2]))
             Δa₂ += u_I * mitc.dNdξ_tie_2[I,k][2]
             φ₁ = u_e[5I-1]; φ₂ = u_e[5I]
-            cosθ, sincθ = _cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
+            cosθ, sincθ = cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
             G₃_I = mitc.G₃_node[I]; T₁_I = mitc.T₁_node[I]; T₂_I = mitc.T₂_node[I]
             d_k2 += mitc.N_tie_2[I,k] * (cosθ*G₃_I + sincθ*(φ₁*T₁_I + φ₂*T₂_I))
         end
@@ -521,7 +603,10 @@ function bending_tangent_RM!(ke, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::Abs
         L₁₁, L₁₂, L₂₂ = frame_stiffness(D, d₁, d₂)
         dΩ  = scv.detJdV[qp]
 
-        # MITC-consistent shear sensitivities for each node J at this QP
+        # MITC shear strain sensitivities ∂γ_α/∂(dofs of node J), stored as the components
+        # of a 5-vector per node (u₁,u₂,u₃,φ₁,φ₂). The shear tangent is then assembled
+        # consistently for *all* DOF blocks as the symmetric material outer product
+        # Σ_αβ Cs[α,β] Bγ_α(I) ⊗ Bγ_β(J) plus the geometric (initial-stress) Q·∂²γ part.
         for J in 1:n_nodes
             Bγ₁u[J]  = zero(Vec{3,T}); Bγ₂u[J]  = zero(Vec{3,T})
             Bγ₁φ1[J] = zero(T);        Bγ₁φ2[J] = zero(T)
@@ -536,56 +621,72 @@ function bending_tangent_RM!(ke, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::Abs
                 Bγ₂φ2[J] += h2 * mitc.N_tie_2[J,k] * dot(a₂_tie[k], dd2_J[J])
             end
         end
+        Bγ1(J) = (Bγ₁u[J][1], Bγ₁u[J][2], Bγ₁u[J][3], Bγ₁φ1[J], Bγ₁φ2[J])
+        Bγ2(J) = (Bγ₂u[J][1], Bγ₂u[J][2], Bγ₂u[J][3], Bγ₂φ1[J], Bγ₂φ2[J])
 
         for I in 1:n_nodes
-            ∂NI1, ∂NI2 = scv.dNdξ[I, qp]; NI = scv.N[I, qp]
-            F_I = ∂NI1*S¹ + ∂NI2*S² + NI*(Q₁*a₁ + Q₂*a₂)
+            ∂NI1, ∂NI2 = scv.dNdξ[I, qp]
+            Sb_I = ∂NI1*S¹ + ∂NI2*S²                 # bending traction at I (geometric φφ)
             φ₁_I = u_e[5I-1]; φ₂_I = u_e[5I]
             s_I, sc_I, dd_I1, dd_I2 = rodrigues_jac(φ₁_I, φ₂_I, scv.G₃_elem[I], scv.T₁_elem[I], scv.T₂_elem[I])
             θ²_I = φ₁_I^2 + φ₂_I^2
+            b1I = Bγ1(I); b2I = Bγ2(I)
             for J in 1:n_nodes
-                ∂NJ1, ∂NJ2 = scv.dNdξ[J, qp]; NJ = scv.N[J, qp]
-                # uu block: bending frame stiffness (unchanged) + MITC-consistent shear
-                K_bend  = ∂NI1*∂NJ1*L₁₁ + ∂NI1*∂NJ2*L₁₂ + ∂NI2*∂NJ1*transpose(L₁₂) + ∂NI2*∂NJ2*L₂₂
-                K_shear = Cs[1,1]*(Bγ₁u[I]⊗Bγ₁u[J]) + Cs[1,2]*(Bγ₁u[I]⊗Bγ₂u[J]) +
-                          Cs[2,1]*(Bγ₂u[I]⊗Bγ₁u[J]) + Cs[2,2]*(Bγ₂u[I]⊗Bγ₂u[J])
-                @views ke[5I-4:5I-2, 5J-4:5J-2] .+= (K_bend + K_shear) * dΩ
-                # uφ and φφ material blocks
+                ∂NJ1, ∂NJ2 = scv.dNdξ[J, qp]
+                # uu bending block: frame stiffness with d₁,d₂ (QP-direct, unchanged)
+                K_bend = ∂NI1*∂NJ1*L₁₁ + ∂NI1*∂NJ2*L₁₂ + ∂NI2*∂NJ1*transpose(L₁₂) + ∂NI2*∂NJ2*L₂₂
+                @views ke[5I-4:5I-2, 5J-4:5J-2] .+= K_bend * dΩ
+                # MITC shear material: symmetric 5×5 outer product over all DOFs of (I,J)
+                b1J = Bγ1(J); b2J = Bγ2(J)
+                @inbounds for p in 1:5, q in 1:5
+                    cbq = b1I[p]*(Cs[1,1]*b1J[q] + Cs[1,2]*b2J[q]) +
+                          b2I[p]*(Cs[2,1]*b1J[q] + Cs[2,2]*b2J[q])
+                    ke[5(I-1)+p, 5(J-1)+q] += cbq * dΩ
+                end
+                # bending uφ/φφ material (κ/D, QP-direct) + bending geometric (Mb)
                 φ₁_J = u_e[5J-1]; φ₂_J = u_e[5J]
                 _, _, dd_J1, dd_J2 = rodrigues_jac(φ₁_J, φ₂_J, scv.G₃_elem[J], scv.T₁_elem[J], scv.T₂_elem[J])
                 g_IJ = ∂NI1*(Mb[1,1]*∂NJ1+Mb[1,2]*∂NJ2) + ∂NI2*(Mb[2,1]*∂NJ1+Mb[2,2]*∂NJ2)
-                q_I  = ∂NI1*Q₁ + ∂NI2*Q₂
-                for (l, dd_Jl, Bγ₁φl, Bγ₂φl) in ((1, dd_J1, Bγ₁φ1[J], Bγ₂φ1[J]),
-                                                    (2, dd_J2, Bγ₁φ2[J], Bγ₂φ2[J]))
+                # MITC shear geometric coupling ∂²γ/∂u_I∂φ_J : Σ_k h_α ∂N_tie(I) N_tie(J)
+                gu1 = zero(T); gu2 = zero(T)
+                @inbounds for k in 1:Nt
+                    gu1 += mitc.h_tie_1[qp,k] * mitc.dNdξ_tie_1[I,k][1] * mitc.N_tie_1[J,k]
+                    gu2 += mitc.h_tie_2[qp,k] * mitc.dNdξ_tie_2[I,k][2] * mitc.N_tie_2[J,k]
+                end
+                qg = Q₁*gu1 + Q₂*gu2
+                for (l, dd_Jl, dd_Jl_n) in ((1, dd_J1, dd1_J[J]), (2, dd_J2, dd2_J[J]))
                     c₁ = dot(a₁, dd_Jl); c₂ = dot(a₂, dd_Jl)  # bending δκ: QP geometry
                     δκ = SymmetricTensor{2,2,T}((∂NJ1*c₁, 0.5*(∂NJ1*c₂+∂NJ2*c₁), ∂NJ2*c₂))
                     δM = D ⊡ δκ
-                    # MITC-consistent shear for uφ: Bγ_φl contains N_tie factor, no NJ
-                    δQ₁ = Cs[1,1]*Bγ₁φl + Cs[1,2]*Bγ₂φl
-                    δQ₂ = Cs[2,1]*Bγ₁φl + Cs[2,2]*Bγ₂φl
                     col = 5J - 2 + l
-                    v_bend  = ∂NI1*(δM[1,1]*d₁+δM[1,2]*d₂) + ∂NI2*(δM[2,1]*d₁+δM[2,2]*d₂)
-                    v_shear = (∂NI1*δQ₁ + ∂NI2*δQ₂) * d    # no NJ: Bγ already accounts for it
-                    v_dir   = (g_IJ + q_I*NJ) * dd_Jl       # Q·δd: director at QP
-                    @views ke[5I-4:5I-2, col] .+= (v_bend + v_shear + v_dir) * dΩ
-                    @views ke[col, 5I-4:5I-2] .+= (v_bend + v_shear + v_dir) * dΩ  # φu by symmetry
+                    v_bend = ∂NI1*(δM[1,1]*d₁+δM[1,2]*d₂) + ∂NI2*(δM[2,1]*d₁+δM[2,2]*d₂)
+                    v_dir  = g_IJ * dd_Jl                   # bending Mb·δd at QP
+                    v_shg  = qg * dd_Jl_n                   # MITC shear Q·∂²γ (initial stress)
+                    @views ke[5I-4:5I-2, col] .+= (v_bend + v_dir + v_shg) * dΩ
+                    @views ke[col, 5I-4:5I-2] .+= (v_bend + v_dir + v_shg) * dΩ  # by symmetry
                     δS¹  = δM[1,1]*a₁ + δM[1,2]*a₂
                     δS²  = δM[2,1]*a₁ + δM[2,2]*a₂
-                    δF_I = ∂NI1*δS¹ + ∂NI2*δS² + NI*(δQ₁*a₁ + δQ₂*a₂)  # no NJ: in Bγ
+                    δF_I = ∂NI1*δS¹ + ∂NI2*δS²              # bending φφ material (no shear)
                     ke[5I-1, col] += dot(δF_I, dd_I1) * dΩ
                     ke[5I,   col] += dot(δF_I, dd_I2) * dΩ
                 end
             end
-            # φφ geometric part (J=I): F_I uses MITC Q₁,Q₂ — already correct
-            G₃_I = scv.G₃_elem[I]; T₁_I = scv.T₁_elem[I]; T₂_I = scv.T₂_elem[I]
+            # φφ geometric (J=I): bending Sb_I·∂²d (element frame) + shear Q·∂²γ (node frame)
             sccc_I = θ²_I < 1e-6 ? one(T)/15 : (-s_I - 3sc_I)/θ²_I
-            d2_11 = (3sc_I*φ₁_I + sccc_I*φ₁_I^3)*T₁_I + (sc_I + sccc_I*φ₁_I^2)*φ₂_I*T₂_I - (s_I + sc_I*φ₁_I^2)*G₃_I
-            d2_12 = (sc_I + sccc_I*φ₁_I^2)*φ₂_I*T₁_I + (sc_I + sccc_I*φ₂_I^2)*φ₁_I*T₂_I - sc_I*φ₁_I*φ₂_I*G₃_I
-            d2_22 = (sc_I + sccc_I*φ₂_I^2)*φ₁_I*T₁_I + (3sc_I*φ₂_I + sccc_I*φ₂_I^3)*T₂_I - (s_I + sc_I*φ₂_I^2)*G₃_I
-            ke[5I-1, 5I-1] += dot(F_I, d2_11) * dΩ
-            ke[5I-1, 5I  ] += dot(F_I, d2_12) * dΩ
-            ke[5I,   5I-1] += dot(F_I, d2_12) * dΩ
-            ke[5I,   5I  ] += dot(F_I, d2_22) * dΩ
+            d2e_11, d2e_12, d2e_22 = rodrigues_hess(s_I, sc_I, sccc_I, φ₁_I, φ₂_I,
+                                                     scv.G₃_elem[I], scv.T₁_elem[I], scv.T₂_elem[I])
+            W₁ = zero(Vec{3,T}); W₂ = zero(Vec{3,T})
+            @inbounds for k in 1:Nt
+                W₁ += mitc.h_tie_1[qp,k] * mitc.N_tie_1[I,k] * a₁_tie[k]
+                W₂ += mitc.h_tie_2[qp,k] * mitc.N_tie_2[I,k] * a₂_tie[k]
+            end
+            WQ = Q₁*W₁ + Q₂*W₂
+            d2n_11, d2n_12, d2n_22 = rodrigues_hess(s_I, sc_I, sccc_I, φ₁_I, φ₂_I,
+                                                     mitc.G₃_node[I], mitc.T₁_node[I], mitc.T₂_node[I])
+            ke[5I-1, 5I-1] += (dot(Sb_I, d2e_11) + dot(WQ, d2n_11)) * dΩ
+            ke[5I-1, 5I  ] += (dot(Sb_I, d2e_12) + dot(WQ, d2n_12)) * dΩ
+            ke[5I,   5I-1] += (dot(Sb_I, d2e_12) + dot(WQ, d2n_12)) * dΩ
+            ke[5I,   5I  ] += (dot(Sb_I, d2e_22) + dot(WQ, d2n_22)) * dΩ
         end
     end
 end
@@ -696,8 +797,8 @@ end
 # Derived from ξ(t) = 0.5*(1-t)*A + 0.5*(1+t)*B (vertices A, B of facet in ref space).
 # RefQuadrilateral vertices: (-1,-1),(1,-1),(1,1),(-1,1); all facets are axis-aligned.
 # RefTriangle vertices: (0,0),(1,0),(0,1); facet 2 (hypotenuse) has mixed direction.
-@inline _facet_dxi(::Lagrange{RefQuadrilateral}, f::Int) = f ∈ (1,3) ? Vec{2}((1.0, 0.0)) : Vec{2}((0.0, 1.0))
-@inline _facet_dxi(::Lagrange{RefTriangle},      f::Int) =
+@inline facet_dxi(::Lagrange{RefQuadrilateral}, f::Int) = f ∈ (1,3) ? Vec{2}((1.0, 0.0)) : Vec{2}((0.0, 1.0))
+@inline facet_dxi(::Lagrange{RefTriangle},      f::Int) =
     f == 1 ? Vec{2}(( 0.5,  0.0)) :
     f == 2 ? Vec{2}((-0.5,  0.5)) :
              Vec{2}(( 0.0, -0.5))
@@ -723,7 +824,7 @@ function assemble_traction!(f, dh, facetset, ip::Interpolation, fqr::FacetQuadra
         x        = getcoordinates(fc)
         facet_nr = fc.current_facet_id
         qr_f     = fqr.facet_rules[facet_nr]
-        dxi      = _facet_dxi(ip, facet_nr)   # ∂ξ/∂t in reference coords
+        dxi      = facet_dxi(ip, facet_nr)   # ∂ξ/∂t in reference coords
         for (ξ, w) in zip(qr_f.points, qr_f.weights)
             xp = zero(Vec{3,Float64})
             Jt = zero(Vec{3,Float64})  # physical tangent: J * dxi

--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -318,7 +318,8 @@ function energy_RM(u_flat, scv::ShellCellValues, mat)
         κ   = curvature_tensor(a₁, a₂, d₁, d₂, scv.B[qp])
         γ₁, γ₂ = shear_strains(a₁, a₂, d, qp, γ₁_k, γ₂_k, scv.mitc)
         d₀  = reference_director(scv, qp, n_nodes)
-        γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
+        r₁, r₂ = reference_shear_offset(scv.A₁[qp], scv.A₂[qp], d₀, scv.mitc)
+        γ₁ -= r₁; γ₂ -= r₂
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         W += rm_qp_energy(mat, c_ms, κ, γ₁, γ₂, scv.A_metric[qp],
                           scv.A₁[qp], scv.A₂[qp], d₀) * scv.detJdV[qp]
@@ -479,9 +480,8 @@ function bending_residuals_RM!(re, scv::ShellCellValues{QR,IPG,IPS,FT,MITC{NN,MM
         a₁, a₂ = covariant_basis(scv, qp, u_e, NN)
         d, d₁, d₂ = director_field(scv, qp, u_e, NN)
         κ   = curvature_tensor(a₁, a₂, d₁, d₂, scv.B[qp])
-        γ₁, γ₂ = shear_strains(a₁, a₂, d, qp, γ₁_k, γ₂_k, mitc)
+        γ₁, γ₂ = shear_strains(a₁, a₂, d, qp, γ₁_k, γ₂_k, mitc)  # already referenced (MITC)
         d₀  = reference_director(scv, qp, NN)
-        γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp], scv.A₁[qp], scv.A₂[qp], d₀)
         Mb  = D ⊡ κ
@@ -594,9 +594,8 @@ function bending_tangent_RM!(ke, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::Abs
         a₁, a₂ = covariant_basis(scv, qp, u_e, n_nodes)
         d, d₁, d₂ = director_field(scv, qp, u_e, n_nodes)
         κ   = curvature_tensor(a₁, a₂, d₁, d₂, scv.B[qp])
-        γ₁, γ₂ = shear_strains(a₁, a₂, d, qp, γ₁_k, γ₂_k, mitc)
+        γ₁, γ₂ = shear_strains(a₁, a₂, d, qp, γ₁_k, γ₂_k, mitc)  # already referenced (MITC)
         d₀  = reference_director(scv, qp, n_nodes)
-        γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp], scv.A₁[qp], scv.A₂[qp], d₀)
         Mb  = D ⊡ κ

--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -444,41 +444,43 @@ end
 # Only then is the residual the exact gradient of energy_RM (conservative ⇒ symmetric
 # tangent). The QP-direct variant is only ~O(1%) accurate and non-symmetric on curved
 # elements. Bending (κ/D) terms are QP-direct as in the NoMITC path.
-function bending_residuals_RM!(re, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::AbstractVector{T}, mat) where {QR,IPG,IPS,FT<:AbstractFloat,M<:MITC,T}
-    mitc    = scv.mitc
-    n_nodes = getnbasefunctions(scv.ip_shape)
-    Nt      = length(mitc.ξ_tie_1)
-
-    a₁_tie = Vector{Vec{3,T}}(undef, Nt); d_tie1 = Vector{Vec{3,T}}(undef, Nt)
-    a₂_tie = Vector{Vec{3,T}}(undef, Nt); d_tie2 = Vector{Vec{3,T}}(undef, Nt)
-    for k in 1:Nt
-        Δa₁ = zero(Vec{3,T}); dk1 = zero(Vec{3,T})
-        Δa₂ = zero(Vec{3,T}); dk2 = zero(Vec{3,T})
-        for I in 1:n_nodes
+function bending_residuals_RM!(re, scv::ShellCellValues{QR,IPG,IPS,FT,MITC{NN,MM,MT}}, u_e::AbstractVector{T}, mat) where {QR,IPG,IPS,FT<:AbstractFloat,NN,MM,MT,T}
+    mitc = scv.mitc
+    # Tying-point deformed tangents/directors and per-node Rodrigues Jacobians (node frame),
+    # built as stack-allocated tuples (Val(MM)/Val(NN)) so the kernel stays allocation-free
+    # *and* ForwardDiff-safe — the MITC scratch arrays are Float64-only.
+    tie1 = ntuple(Val(MM)) do k
+        Δa = zero(Vec{3,T}); dk = zero(Vec{3,T})
+        @inbounds for I in 1:NN
             u_I = Vec{3,T}((u_e[5I-4], u_e[5I-3], u_e[5I-2]))
-            Δa₁ += u_I * mitc.dNdξ_tie_1[I,k][1]
-            Δa₂ += u_I * mitc.dNdξ_tie_2[I,k][2]
+            Δa += u_I * mitc.dNdξ_tie_1[I,k][1]
             φ₁ = u_e[5I-1]; φ₂ = u_e[5I]; cosθ, sincθ = cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
-            dI = cosθ*mitc.G₃_node[I] + sincθ*(φ₁*mitc.T₁_node[I] + φ₂*mitc.T₂_node[I])
-            dk1 += mitc.N_tie_1[I,k] * dI
-            dk2 += mitc.N_tie_2[I,k] * dI
+            dk += mitc.N_tie_1[I,k] * (cosθ*mitc.G₃_node[I] + sincθ*(φ₁*mitc.T₁_node[I] + φ₂*mitc.T₂_node[I]))
         end
-        a₁_tie[k] = mitc.A₁_tie_1[k] + Δa₁; d_tie1[k] = dk1
-        a₂_tie[k] = mitc.A₂_tie_2[k] + Δa₂; d_tie2[k] = dk2
+        (mitc.A₁_tie_1[k] + Δa, dk)
     end
-    dd1n = Vector{Vec{3,T}}(undef, n_nodes); dd2n = Vector{Vec{3,T}}(undef, n_nodes)
-    for I in 1:n_nodes
+    tie2 = ntuple(Val(MM)) do k
+        Δa = zero(Vec{3,T}); dk = zero(Vec{3,T})
+        @inbounds for I in 1:NN
+            u_I = Vec{3,T}((u_e[5I-4], u_e[5I-3], u_e[5I-2]))
+            Δa += u_I * mitc.dNdξ_tie_2[I,k][2]
+            φ₁ = u_e[5I-1]; φ₂ = u_e[5I]; cosθ, sincθ = cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
+            dk += mitc.N_tie_2[I,k] * (cosθ*mitc.G₃_node[I] + sincθ*(φ₁*mitc.T₁_node[I] + φ₂*mitc.T₂_node[I]))
+        end
+        (mitc.A₂_tie_2[k] + Δa, dk)
+    end
+    ddn = ntuple(Val(NN)) do I
         _, _, d1, d2 = rodrigues_jac(u_e[5I-1], u_e[5I], mitc.G₃_node[I], mitc.T₁_node[I], mitc.T₂_node[I])
-        dd1n[I] = d1; dd2n[I] = d2
+        (d1, d2)
     end
 
     γ₁_k, γ₂_k = tying_shear_strains(mitc, u_e)
     for qp in 1:getnquadpoints(scv)
-        a₁, a₂ = covariant_basis(scv, qp, u_e, n_nodes)
-        d, d₁, d₂ = director_field(scv, qp, u_e, n_nodes)
+        a₁, a₂ = covariant_basis(scv, qp, u_e, NN)
+        d, d₁, d₂ = director_field(scv, qp, u_e, NN)
         κ   = curvature_tensor(a₁, a₂, d₁, d₂, scv.B[qp])
         γ₁, γ₂ = shear_strains(a₁, a₂, d, qp, γ₁_k, γ₂_k, mitc)
-        d₀  = reference_director(scv, qp, n_nodes)
+        d₀  = reference_director(scv, qp, NN)
         γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp], scv.A₁[qp], scv.A₂[qp], d₀)
@@ -490,18 +492,20 @@ function bending_residuals_RM!(re, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::A
         S¹  = Mb[1,1]*a₁ + Mb[1,2]*a₂
         S²  = Mb[2,1]*a₁ + Mb[2,2]*a₂
         dΩ  = scv.detJdV[qp]
-        for I in 1:n_nodes
+        @inbounds for I in 1:NN
             ∂NI1, ∂NI2 = scv.dNdξ[I, qp]
+            ddI1 = ddn[I][1]; ddI2 = ddn[I][2]
             Bγ1u = zero(Vec{3,T}); Bγ2u = zero(Vec{3,T})
             Bγ1φ1 = zero(T); Bγ1φ2 = zero(T); Bγ2φ1 = zero(T); Bγ2φ2 = zero(T)
-            @inbounds for k in 1:Nt
+            for k in 1:MM
                 h1 = mitc.h_tie_1[qp,k]; h2 = mitc.h_tie_2[qp,k]
-                Bγ1u  += h1 * mitc.dNdξ_tie_1[I,k][1] * d_tie1[k]
-                Bγ2u  += h2 * mitc.dNdξ_tie_2[I,k][2] * d_tie2[k]
-                Bγ1φ1 += h1 * mitc.N_tie_1[I,k] * dot(a₁_tie[k], dd1n[I])
-                Bγ1φ2 += h1 * mitc.N_tie_1[I,k] * dot(a₁_tie[k], dd2n[I])
-                Bγ2φ1 += h2 * mitc.N_tie_2[I,k] * dot(a₂_tie[k], dd1n[I])
-                Bγ2φ2 += h2 * mitc.N_tie_2[I,k] * dot(a₂_tie[k], dd2n[I])
+                a1t = tie1[k][1]; d1t = tie1[k][2]; a2t = tie2[k][1]; d2t = tie2[k][2]
+                Bγ1u  += h1 * mitc.dNdξ_tie_1[I,k][1] * d1t
+                Bγ2u  += h2 * mitc.dNdξ_tie_2[I,k][2] * d2t
+                Bγ1φ1 += h1 * mitc.N_tie_1[I,k] * dot(a1t, ddI1)
+                Bγ1φ2 += h1 * mitc.N_tie_1[I,k] * dot(a1t, ddI2)
+                Bγ2φ1 += h2 * mitc.N_tie_2[I,k] * dot(a2t, ddI1)
+                Bγ2φ2 += h2 * mitc.N_tie_2[I,k] * dot(a2t, ddI2)
             end
             @views re[5I-4:5I-2] .+= (∂NI1*Pb¹ + ∂NI2*Pb² + Q₁*Bγ1u + Q₂*Bγ2u) * dΩ
             _, _, dd_I1, dd_I2 = rodrigues_jac(u_e[5I-1], u_e[5I], scv.G₃_elem[I], scv.T₁_elem[I], scv.T₂_elem[I])

--- a/src/mitc.jl
+++ b/src/mitc.jl
@@ -177,6 +177,16 @@ Without MITC: direct `dot(a₁, d)`, `dot(a₂, d)`.
     γ₁, γ₂
 end
 
+# Reference (u=0) shear to subtract so the strain is measured from the reference state.
+# NoMITC: QP-direct `dot(A_α, d₀)` (the raw `shear_strains` is not yet referenced).
+# MITC: the tying strains already subtract their own per-tying-point reference, so the
+# interpolated `shear_strains` is referenced — subtracting `dot(A_α, d₀)` again would
+# double-count. That extra term is zero on flat elements (A_α ⟂ d₀) but a spurious
+# reference shear on curved ones, which pre-stresses the reference and renders the
+# tangent indefinite. Dispatch to 0 for MITC.
+@inline reference_shear_offset(A₁, A₂, d₀, ::NoMITC) = dot(A₁, d₀), dot(A₂, d₀)
+@inline reference_shear_offset(A₁, A₂, d₀, ::MITC)    = 0.0, 0.0
+
 # MITC3
 # include("mitc/mitc3.jl")
 # export MITC3

--- a/src/mitc.jl
+++ b/src/mitc.jl
@@ -137,7 +137,7 @@ function tying_shear_strains(mitc::MITC{N,M}, u_e::AbstractVector{T}) where {N,M
             u_I = Vec{3,T}((u_e[5I-4], u_e[5I-3], u_e[5I-2]))
             Δa₁ += u_I * mitc.dNdξ_tie_1[I,k][1]
             φ₁ = u_e[5I-1]; φ₂ = u_e[5I]
-            cosθ, sincθ = _cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
+            cosθ, sincθ = cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
             G₃_I = mitc.G₃_node[I]; T₁_I = mitc.T₁_node[I]; T₂_I = mitc.T₂_node[I]
             d_k += mitc.N_tie_1[I,k] * (cosθ*G₃_I + sincθ*(φ₁*T₁_I + φ₂*T₂_I))
         end
@@ -149,7 +149,7 @@ function tying_shear_strains(mitc::MITC{N,M}, u_e::AbstractVector{T}) where {N,M
             u_I = Vec{3,T}((u_e[5I-4], u_e[5I-3], u_e[5I-2]))
             Δa₂ += u_I * mitc.dNdξ_tie_2[I,k][2]
             φ₁ = u_e[5I-1]; φ₂ = u_e[5I]
-            cosθ, sincθ = _cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
+            cosθ, sincθ = cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
             G₃_I = mitc.G₃_node[I]; T₁_I = mitc.T₁_node[I]; T₂_I = mitc.T₂_node[I]
             d_k += mitc.N_tie_2[I,k] * (cosθ*G₃_I + sincθ*(φ₁*T₁_I + φ₂*T₂_I))
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -269,7 +269,7 @@ function director_field(dh::DofHandler, scv::ShellCellValues, u)
         T2_avg = sum(scv.T₂[q] for q in 1:nq) / nq
         for (I, nid) in enumerate(cell.nodes)
             φ₁ = u_e[5I-1]; φ₂ = u_e[5I]
-            cosθ, sincθ = _cos_sinc_sq(φ₁^2 + φ₂^2)
+            cosθ, sincθ = cos_sinc_sq(φ₁^2 + φ₂^2)
             d_I = cosθ * G3_avg + sincθ * (φ₁ * T1_avg + φ₂ * T2_avg)
             @views d_sum[:, nid]  .+= d_I
             @views G3_sum[:, nid] .+= G3_avg

--- a/test/test_mitc.jl
+++ b/test/test_mitc.jl
@@ -51,11 +51,12 @@
     re_ex_lg = zeros(n_dof); bending_residuals_RM!(re_ex_lg, scv_mitc, u_large, mat)
     re_fd_lg = zeros(n_dof); residuals_RM_FD!(re_fd_lg, scv_mitc, u_large, mat)
     re_mem_lg = zeros(n_dof); membrane_residuals_RM!(re_mem_lg, scv_mitc, u_large, mat)
-    @test norm(re_ex_lg .- (re_fd_lg .- re_mem_lg)) / norm(re_ex_lg) < 1e-2
+    @test norm(re_ex_lg .- (re_fd_lg .- re_mem_lg)) / norm(re_ex_lg) < 1e-10
 
-    # 2b. Consistent MITC9 tangent: bending_tangent_RM! (MITC dispatch) must match
-    #     the ForwardDiff Jacobian of bending_residuals_RM! (not the energy Hessian —
-    #     the MITC explicit residual is not the exact gradient of energy_RM).
+    # 2b. Consistent MITC9 tangent: the explicit MITC residual is the exact gradient of
+    #     energy_RM (it varies the tying-interpolated shear strain via the MITC B-operators),
+    #     so bending_tangent_RM! (MITC dispatch) equals both its ForwardDiff Jacobian and the
+    #     energy Hessian, and is symmetric — on curved elements too.
     ke_ex  = zeros(n_dof, n_dof)
     bending_tangent_RM!(ke_ex, scv_mitc, u_pert, mat)
     ke_jac = ForwardDiff.jacobian(u -> begin
@@ -63,7 +64,8 @@
         bending_residuals_RM!(re, scv_mitc, u, mat)
         re
     end, u_pert)
-    @test norm(ke_ex .- ke_jac) / norm(ke_jac) < 1e-3
+    @test norm(ke_ex .- ke_jac) / norm(ke_jac) < 1e-8
+    @test norm(ke_ex .- ke_ex') / norm(ke_ex) < 1e-10   # symmetric (conservative residual)
 
     # At zero state: tangent matches Jacobian of residual to near-machine precision.
     ke_ex0  = zeros(n_dof, n_dof)

--- a/test/test_mitc.jl
+++ b/test/test_mitc.jl
@@ -103,6 +103,35 @@
     @test W_mitc ≈ W_nomitc rtol=1e-6
 end
 
+@testset "MITC9 curved-element reference state is stress-free (positive definite)" begin
+    # On a doubly-curved element the MITC tying strains are already referenced, so the
+    # QP reference subtraction `dot(A_α, d₀)` must NOT be applied again — doing so injects
+    # a spurious reference shear (zero on flat elements, nonzero on curved) that pre-stresses
+    # u=0 and makes the tangent indefinite. Regression guard for that double-subtraction.
+    mat = LinearElastic(1.0e6, 0.3, 0.01)
+    ip  = Lagrange{RefQuadrilateral, 2}()
+    qr  = QuadratureRule{RefQuadrilateral}(3)
+    # warp the flat unit Q9 onto a paraboloid z = 0.15(x²+y²)
+    X_curv = [Vec{3}((p[1], p[2], 0.15*(p[1]^2 + p[2]^2))) for p in X_Q9_UNIT]
+
+    scv_mitc   = ShellCellValues(qr, ip, ip; mitc=MITC9)
+    scv_nomitc = ShellCellValues(qr, ip, ip)
+    reinit!(scv_mitc,   X_curv)
+    reinit!(scv_nomitc, X_curv)
+
+    # reference (u=0) residual: MITC must not add spurious internal force beyond NoMITC
+    re_m  = zeros(45); residuals_RM_FD!(re_m,  scv_mitc,   zeros(45), mat)
+    re_nm = zeros(45); residuals_RM_FD!(re_nm, scv_nomitc, zeros(45), mat)
+    @test norm(re_m) ≤ 2 * norm(re_nm) + 1e-6
+
+    # tangent at u=0 must be positive semidefinite: exactly 6 zero modes, no negative ones
+    ke = zeros(45, 45); tangent_RM_FD!(ke, scv_mitc, zeros(45), mat)
+    λ  = eigvals(Symmetric(ke))
+    tol = 1e-7 * maximum(abs, λ)
+    @test count(<(-tol), λ) == 0
+    @test count(v -> abs(v) ≤ tol, λ) == 6
+end
+
 @testset "MITC9 anti-locking: thin SS plate h-convergence" begin
     # Simply-supported square plate [0,1]² under sinusoidal load q₀·sin(πx)·sin(πy).
     # Same reference as the NoMITC h-convergence test in test_rm.jl.


### PR DESCRIPTION
The explicit MITC `bending_residuals_RM!` varied the transverse-shear term with QP-direct B-operators (∂N·d, N·(a·dd)) even though the shear strain γ is `MITC` tying-interpolated. The residual was therefore not the variation of the assumed strain field — i.e. non-conservative — so its tangent is non-symmetric and indefinite on non-affine (curved) elements. At the stress-free flat state the annular-element tangent had ~5e-3 asymmetry and ~half-negative eigenvalues, so Newton diverged at any load. Affine elements masked it (QP-direct ≈ tying, ~1% off).

### Fix
Make both the residual and tangent use the `MITC` tying B-operators (Bγ), so the residual is the exact gradient of `energy_RM` and the tangent its exact Hessian:
- Residual (`M<:MITC` dispatch): shear residual = Q_α·Bγ_α; bending stays QP-direct.
- Tangent: shear material = symmetric outer product Σ Cs[α,β]·Bγ_α(I)⊗Bγ_β(J); shear geometric (initial-stress) = Σ Q_α·∂²γ_α (uφ cross-term + φφ diagonal). New helper `rodrigues_hess` for ∂²d/∂φ².

### Verification
- Explicit residual/tangent now equal `residuals_RM_FD!` / `tangent_RM_FD!` (and the residual Jacobian) to machine precision, symmetric, on curved and affine elements.
- Full test suite passes; `test_mitc` tolerances tightened to 1e-10/1e-8 + a symmetry assertion.
- New `examples/SlitAnnularPlate.jl` (Sze et al. 2004 benchmark): FerriteGmsh zero-gap-slit mesh, load control + ¼ increment cutback, fast explicit assembly; reaches λ=1 with u_z(A)=16.84, u_z(B)=13.31.