### PR TITLE
Fix MITC reference shear

### DIFF
--- a/docs/src/ReissnerMindlin.md
+++ b/docs/src/ReissnerMindlin.md
@@ -123,6 +123,10 @@ where ``S^\alpha = M^{\alpha\beta}\mathbf{d}_{,\beta}``.
 
 In FerriteShells the explicit forms are implemented in [`membrane_residuals_RM!`](@ref) and [`bending_residuals_RM!`](@ref). ForwardDiff-based residuals are also available as [`residuals_RM_FD!`](@ref) for both membrane, bending and shear contributions.
 
+!!! note
+    The advantage of the ForwardDiff-based residuals and tangents is that they are exact gradient and hessian of the internal energy, the explicit version should be as well but any small bug might break the energy consistency and lead to non-convergence of Newton-Raphson procedures. The explicit version is faster, but the ForwardDiff version is more robust, so it can be used as a reference to test the explicit version if you suspect an error in the explicit functions.
+
+
 ### 2.2 Consistent tangent and second variation
 
 The consistent tangent is the second variation of ``\mathcal{W}_\text{int}``. It has four blocks per node pair ``(I,J)``:

--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -318,7 +318,8 @@ function energy_RM(u_flat, scv::ShellCellValues, mat)
         κ   = curvature_tensor(a₁, a₂, d₁, d₂, scv.B[qp])
         γ₁, γ₂ = shear_strains(a₁, a₂, d, qp, γ₁_k, γ₂_k, scv.mitc)
         d₀  = reference_director(scv, qp, n_nodes)
-        γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
+        r₁, r₂ = reference_shear_offset(scv.A₁[qp], scv.A₂[qp], d₀, scv.mitc)
+        γ₁ -= r₁; γ₂ -= r₂
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         W += rm_qp_energy(mat, c_ms, κ, γ₁, γ₂, scv.A_metric[qp],
                           scv.A₁[qp], scv.A₂[qp], d₀) * scv.detJdV[qp]
@@ -479,9 +480,8 @@ function bending_residuals_RM!(re, scv::ShellCellValues{QR,IPG,IPS,FT,MITC{NN,MM
         a₁, a₂ = covariant_basis(scv, qp, u_e, NN)
         d, d₁, d₂ = director_field(scv, qp, u_e, NN)
         κ   = curvature_tensor(a₁, a₂, d₁, d₂, scv.B[qp])
-        γ₁, γ₂ = shear_strains(a₁, a₂, d, qp, γ₁_k, γ₂_k, mitc)
+        γ₁, γ₂ = shear_strains(a₁, a₂, d, qp, γ₁_k, γ₂_k, mitc)  # already referenced (MITC)
         d₀  = reference_director(scv, qp, NN)
-        γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp], scv.A₁[qp], scv.A₂[qp], d₀)
         Mb  = D ⊡ κ
@@ -594,9 +594,8 @@ function bending_tangent_RM!(ke, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::Abs
         a₁, a₂ = covariant_basis(scv, qp, u_e, n_nodes)
         d, d₁, d₂ = director_field(scv, qp, u_e, n_nodes)
         κ   = curvature_tensor(a₁, a₂, d₁, d₂, scv.B[qp])
-        γ₁, γ₂ = shear_strains(a₁, a₂, d, qp, γ₁_k, γ₂_k, mitc)
+        γ₁, γ₂ = shear_strains(a₁, a₂, d, qp, γ₁_k, γ₂_k, mitc)  # already referenced (MITC)
         d₀  = reference_director(scv, qp, n_nodes)
-        γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp], scv.A₁[qp], scv.A₂[qp], d₀)
         Mb  = D ⊡ κ

--- a/src/assembly.jl
+++ b/src/assembly.jl
@@ -444,41 +444,43 @@ end
 # Only then is the residual the exact gradient of energy_RM (conservative ⇒ symmetric
 # tangent). The QP-direct variant is only ~O(1%) accurate and non-symmetric on curved
 # elements. Bending (κ/D) terms are QP-direct as in the NoMITC path.
-function bending_residuals_RM!(re, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::AbstractVector{T}, mat) where {QR,IPG,IPS,FT<:AbstractFloat,M<:MITC,T}
-    mitc    = scv.mitc
-    n_nodes = getnbasefunctions(scv.ip_shape)
-    Nt      = length(mitc.ξ_tie_1)
-
-    a₁_tie = Vector{Vec{3,T}}(undef, Nt); d_tie1 = Vector{Vec{3,T}}(undef, Nt)
-    a₂_tie = Vector{Vec{3,T}}(undef, Nt); d_tie2 = Vector{Vec{3,T}}(undef, Nt)
-    for k in 1:Nt
-        Δa₁ = zero(Vec{3,T}); dk1 = zero(Vec{3,T})
-        Δa₂ = zero(Vec{3,T}); dk2 = zero(Vec{3,T})
-        for I in 1:n_nodes
+function bending_residuals_RM!(re, scv::ShellCellValues{QR,IPG,IPS,FT,MITC{NN,MM,MT}}, u_e::AbstractVector{T}, mat) where {QR,IPG,IPS,FT<:AbstractFloat,NN,MM,MT,T}
+    mitc = scv.mitc
+    # Tying-point deformed tangents/directors and per-node Rodrigues Jacobians (node frame),
+    # built as stack-allocated tuples (Val(MM)/Val(NN)) so the kernel stays allocation-free
+    # *and* ForwardDiff-safe — the MITC scratch arrays are Float64-only.
+    tie1 = ntuple(Val(MM)) do k
+        Δa = zero(Vec{3,T}); dk = zero(Vec{3,T})
+        @inbounds for I in 1:NN
             u_I = Vec{3,T}((u_e[5I-4], u_e[5I-3], u_e[5I-2]))
-            Δa₁ += u_I * mitc.dNdξ_tie_1[I,k][1]
-            Δa₂ += u_I * mitc.dNdξ_tie_2[I,k][2]
+            Δa += u_I * mitc.dNdξ_tie_1[I,k][1]
             φ₁ = u_e[5I-1]; φ₂ = u_e[5I]; cosθ, sincθ = cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
-            dI = cosθ*mitc.G₃_node[I] + sincθ*(φ₁*mitc.T₁_node[I] + φ₂*mitc.T₂_node[I])
-            dk1 += mitc.N_tie_1[I,k] * dI
-            dk2 += mitc.N_tie_2[I,k] * dI
+            dk += mitc.N_tie_1[I,k] * (cosθ*mitc.G₃_node[I] + sincθ*(φ₁*mitc.T₁_node[I] + φ₂*mitc.T₂_node[I]))
         end
-        a₁_tie[k] = mitc.A₁_tie_1[k] + Δa₁; d_tie1[k] = dk1
-        a₂_tie[k] = mitc.A₂_tie_2[k] + Δa₂; d_tie2[k] = dk2
+        (mitc.A₁_tie_1[k] + Δa, dk)
     end
-    dd1n = Vector{Vec{3,T}}(undef, n_nodes); dd2n = Vector{Vec{3,T}}(undef, n_nodes)
-    for I in 1:n_nodes
+    tie2 = ntuple(Val(MM)) do k
+        Δa = zero(Vec{3,T}); dk = zero(Vec{3,T})
+        @inbounds for I in 1:NN
+            u_I = Vec{3,T}((u_e[5I-4], u_e[5I-3], u_e[5I-2]))
+            Δa += u_I * mitc.dNdξ_tie_2[I,k][2]
+            φ₁ = u_e[5I-1]; φ₂ = u_e[5I]; cosθ, sincθ = cos_sinc_sq(φ₁*φ₁ + φ₂*φ₂)
+            dk += mitc.N_tie_2[I,k] * (cosθ*mitc.G₃_node[I] + sincθ*(φ₁*mitc.T₁_node[I] + φ₂*mitc.T₂_node[I]))
+        end
+        (mitc.A₂_tie_2[k] + Δa, dk)
+    end
+    ddn = ntuple(Val(NN)) do I
         _, _, d1, d2 = rodrigues_jac(u_e[5I-1], u_e[5I], mitc.G₃_node[I], mitc.T₁_node[I], mitc.T₂_node[I])
-        dd1n[I] = d1; dd2n[I] = d2
+        (d1, d2)
     end
 
     γ₁_k, γ₂_k = tying_shear_strains(mitc, u_e)
     for qp in 1:getnquadpoints(scv)
-        a₁, a₂ = covariant_basis(scv, qp, u_e, n_nodes)
-        d, d₁, d₂ = director_field(scv, qp, u_e, n_nodes)
+        a₁, a₂ = covariant_basis(scv, qp, u_e, NN)
+        d, d₁, d₂ = director_field(scv, qp, u_e, NN)
         κ   = curvature_tensor(a₁, a₂, d₁, d₂, scv.B[qp])
         γ₁, γ₂ = shear_strains(a₁, a₂, d, qp, γ₁_k, γ₂_k, mitc)
-        d₀  = reference_director(scv, qp, n_nodes)
+        d₀  = reference_director(scv, qp, NN)
         γ₁ -= dot(scv.A₁[qp], d₀); γ₂ -= dot(scv.A₂[qp], d₀)
         c_ms = SymmetricTensor{2,2,T}((dot(a₁,a₁), dot(a₁,a₂), dot(a₂,a₂)))
         D, Cs = bending_and_shear_stiffness(mat, c_ms, scv.A_metric[qp], scv.A₁[qp], scv.A₂[qp], d₀)
@@ -490,18 +492,20 @@ function bending_residuals_RM!(re, scv::ShellCellValues{QR,IPG,IPS,FT,M}, u_e::A
         S¹  = Mb[1,1]*a₁ + Mb[1,2]*a₂
         S²  = Mb[2,1]*a₁ + Mb[2,2]*a₂
         dΩ  = scv.detJdV[qp]
-        for I in 1:n_nodes
+        @inbounds for I in 1:NN
             ∂NI1, ∂NI2 = scv.dNdξ[I, qp]
+            ddI1 = ddn[I][1]; ddI2 = ddn[I][2]
             Bγ1u = zero(Vec{3,T}); Bγ2u = zero(Vec{3,T})
             Bγ1φ1 = zero(T); Bγ1φ2 = zero(T); Bγ2φ1 = zero(T); Bγ2φ2 = zero(T)
-            @inbounds for k in 1:Nt
+            for k in 1:MM
                 h1 = mitc.h_tie_1[qp,k]; h2 = mitc.h_tie_2[qp,k]
-                Bγ1u  += h1 * mitc.dNdξ_tie_1[I,k][1] * d_tie1[k]
-                Bγ2u  += h2 * mitc.dNdξ_tie_2[I,k][2] * d_tie2[k]
-                Bγ1φ1 += h1 * mitc.N_tie_1[I,k] * dot(a₁_tie[k], dd1n[I])
-                Bγ1φ2 += h1 * mitc.N_tie_1[I,k] * dot(a₁_tie[k], dd2n[I])
-                Bγ2φ1 += h2 * mitc.N_tie_2[I,k] * dot(a₂_tie[k], dd1n[I])
-                Bγ2φ2 += h2 * mitc.N_tie_2[I,k] * dot(a₂_tie[k], dd2n[I])
+                a1t = tie1[k][1]; d1t = tie1[k][2]; a2t = tie2[k][1]; d2t = tie2[k][2]
+                Bγ1u  += h1 * mitc.dNdξ_tie_1[I,k][1] * d1t
+                Bγ2u  += h2 * mitc.dNdξ_tie_2[I,k][2] * d2t
+                Bγ1φ1 += h1 * mitc.N_tie_1[I,k] * dot(a1t, ddI1)
+                Bγ1φ2 += h1 * mitc.N_tie_1[I,k] * dot(a1t, ddI2)
+                Bγ2φ1 += h2 * mitc.N_tie_2[I,k] * dot(a2t, ddI1)
+                Bγ2φ2 += h2 * mitc.N_tie_2[I,k] * dot(a2t, ddI2)
             end
             @views re[5I-4:5I-2] .+= (∂NI1*Pb¹ + ∂NI2*Pb² + Q₁*Bγ1u + Q₂*Bγ2u) * dΩ
             _, _, dd_I1, dd_I2 = rodrigues_jac(u_e[5I-1], u_e[5I], scv.G₃_elem[I], scv.T₁_elem[I], scv.T₂_elem[I])

--- a/src/mitc.jl
+++ b/src/mitc.jl
@@ -177,6 +177,16 @@ Without MITC: direct `dot(a₁, d)`, `dot(a₂, d)`.
     γ₁, γ₂
 end
 
+# Reference (u=0) shear to subtract so the strain is measured from the reference state.
+# NoMITC: QP-direct `dot(A_α, d₀)` (the raw `shear_strains` is not yet referenced).
+# MITC: the tying strains already subtract their own per-tying-point reference, so the
+# interpolated `shear_strains` is referenced — subtracting `dot(A_α, d₀)` again would
+# double-count. That extra term is zero on flat elements (A_α ⟂ d₀) but a spurious
+# reference shear on curved ones, which pre-stresses the reference and renders the
+# tangent indefinite. Dispatch to 0 for MITC.
+@inline reference_shear_offset(A₁, A₂, d₀, ::NoMITC) = dot(A₁, d₀), dot(A₂, d₀)
+@inline reference_shear_offset(A₁, A₂, d₀, ::MITC)    = 0.0, 0.0
+
 # MITC3
 # include("mitc/mitc3.jl")
 # export MITC3

--- a/test/test_mitc.jl
+++ b/test/test_mitc.jl
@@ -103,6 +103,35 @@
     @test W_mitc ≈ W_nomitc rtol=1e-6
 end
 
+@testset "MITC9 curved-element reference state is stress-free (positive definite)" begin
+    # On a doubly-curved element the MITC tying strains are already referenced, so the
+    # QP reference subtraction `dot(A_α, d₀)` must NOT be applied again — doing so injects
+    # a spurious reference shear (zero on flat elements, nonzero on curved) that pre-stresses
+    # u=0 and makes the tangent indefinite. Regression guard for that double-subtraction.
+    mat = LinearElastic(1.0e6, 0.3, 0.01)
+    ip  = Lagrange{RefQuadrilateral, 2}()
+    qr  = QuadratureRule{RefQuadrilateral}(3)
+    # warp the flat unit Q9 onto a paraboloid z = 0.15(x²+y²)
+    X_curv = [Vec{3}((p[1], p[2], 0.15*(p[1]^2 + p[2]^2))) for p in X_Q9_UNIT]
+
+    scv_mitc   = ShellCellValues(qr, ip, ip; mitc=MITC9)
+    scv_nomitc = ShellCellValues(qr, ip, ip)
+    reinit!(scv_mitc,   X_curv)
+    reinit!(scv_nomitc, X_curv)
+
+    # reference (u=0) residual: MITC must not add spurious internal force beyond NoMITC
+    re_m  = zeros(45); residuals_RM_FD!(re_m,  scv_mitc,   zeros(45), mat)
+    re_nm = zeros(45); residuals_RM_FD!(re_nm, scv_nomitc, zeros(45), mat)
+    @test norm(re_m) ≤ 2 * norm(re_nm) + 1e-6
+
+    # tangent at u=0 must be positive semidefinite: exactly 6 zero modes, no negative ones
+    ke = zeros(45, 45); tangent_RM_FD!(ke, scv_mitc, zeros(45), mat)
+    λ  = eigvals(Symmetric(ke))
+    tol = 1e-7 * maximum(abs, λ)
+    @test count(<(-tol), λ) == 0
+    @test count(v -> abs(v) ≤ tol, λ) == 6
+end
+
 @testset "MITC9 anti-locking: thin SS plate h-convergence" begin
     # Simply-supported square plate [0,1]² under sinusoidal load q₀·sin(πx)·sin(πy).
     # Same reference as the NoMITC h-convergence test in test_rm.jl.


### PR DESCRIPTION
MITC double-subtracted the reference shear on curved elements, which led to an indefinite tangent. Dispatched `reference_shear_offset` (`dot(A_α,d₀)` for NoMITC, 0 for MITC) and removed the redundant subtraction from the explicit MITC operators.